### PR TITLE
Fix showing the exponent part if a number contains it. Fixes quicksilver/quicksilver#1663

### DIFF
--- a/CalculatorAction.m
+++ b/CalculatorAction.m
@@ -188,7 +188,14 @@
         NSInteger numberOfDecimalPlaces = 7 - ([[components objectAtIndex:0] length]);
         if (numberOfDecimalPlaces > 0) {
             NSUInteger decimalLength = numberOfDecimalPlaces > (NSInteger)[[components lastObject] length] ? [[components lastObject] length] : numberOfDecimalPlaces;
-            outString = [NSString stringWithFormat:@"%@%@%@", [groupedComponents objectAtIndex:0], decimalSeparator, [[groupedComponents lastObject] substringWithRange:NSMakeRange(0, decimalLength)]];
+            NSRange powerQualifierRange = [[components lastObject] rangeOfString:@"e"];
+            NSString *powerQualifierString = nil;
+            if (powerQualifierRange.location != NSNotFound) {
+                NSUInteger powerQualifierLength = [[components lastObject] length] - powerQualifierRange.location;
+                decimalLength = decimalLength - powerQualifierLength;
+                powerQualifierString = [[components lastObject] substringFromIndex:powerQualifierRange.location];
+            }
+            outString = [NSString stringWithFormat:@"%@%@%@%@", [groupedComponents objectAtIndex:0], decimalLength > 0 ? decimalSeparator : @"", decimalLength > 0 ? [[groupedComponents lastObject] substringWithRange:NSMakeRange(0, decimalLength)] : @"", powerQualifierString ? powerQualifierString : @""];
         } else {
             outString = [groupedComponents objectAtIndex:0];
         }

--- a/Info.plist
+++ b/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.2.1</string>
+	<string>2.2.2</string>
 	<key>CFBundleVersion</key>
-	<string>22C</string>
+	<string>22F</string>
 	<key>QSActions</key>
 	<dict>
 		<key>CalculatorCalculateFormulaAction</key>
@@ -109,7 +109,7 @@ To calculate expressions you can run the &apos;Calculate&apos; action on a text 
 	<key>QSRequirements</key>
 	<dict>
 		<key>version</key>
-		<string>3936</string>
+		<string>4001</string>
 	</dict>
 </dict>
 </plist>


### PR DESCRIPTION
Fixes quicksilver/quicksilver#1663

I'd been completely ignoring the `e07` or whatever as part of the number before. Not any more
